### PR TITLE
Feature/rework timeline events

### DIFF
--- a/lib/ex_debug_toolbar/data/timeline.ex
+++ b/lib/ex_debug_toolbar/data/timeline.ex
@@ -12,22 +12,22 @@ defmodule ExDebugToolbar.Data.Timeline do
   end
 
   def start_event(%Timeline{} = timeline, name) do
-    event = %Timeline.Event{name: name, started_at: DateTime.utc_now(), events: []}
+    event = %Timeline.Event{name: name, started_at: DateTime.utc_now()}
     %{timeline | queue: [event | timeline.queue]}
   end
 
   def finish_event(%Timeline{queue: [%{name: name} = event]} = timeline, name) do
     events = timeline.events
-    closed_event = update_duration(event)
+    finished_event = update_duration(event)
     %{timeline |
       queue: [],
-      events: [closed_event | events],
-      duration: closed_event.duration + timeline.duration
+      events: [finished_event | events],
+      duration: finished_event.duration + timeline.duration
     }
   end
   def finish_event(%Timeline{queue: [%{name: name} = event | [parent | rest]]} = timeline, name) do
-    closed_event = update_duration(event)
-    new_parent = %{parent | events: [closed_event | parent.events]}
+    finished_event = update_duration(event)
+    new_parent = %{parent | events: [finished_event | parent.events]}
     %{timeline | queue: [new_parent | rest]}
   end
   def finish_event(_timeline, name), do: raise "the event #{name} is not open"

--- a/lib/ex_debug_toolbar/data/timeline.ex
+++ b/lib/ex_debug_toolbar/data/timeline.ex
@@ -3,14 +3,12 @@ defmodule ExDebugToolbar.Data.Timeline do
 
   defstruct [
     events: [],
+    duration: 0,
     queue: []
   ]
 
   def duration(%Timeline{} = timeline) do
-    timeline.events
-    |> Stream.map(&(&1.duration))
-    |> Stream.reject(&is_nil/1)
-    |> Enum.sum
+    timeline.duration
   end
 
   def start_event(%Timeline{} = timeline, name) do
@@ -20,7 +18,7 @@ defmodule ExDebugToolbar.Data.Timeline do
 
   def finish_event(%Timeline{queue: [event], events: events} = timeline, name) do
     closed_event = update_duration(event)
-    %{timeline | queue: [], events: [closed_event | events]}
+    %{timeline | queue: [], events: [closed_event | events], duration: closed_event.duration + timeline.duration}
   end
   def finish_event(%Timeline{queue: [event | [parent | rest]], events: events} = timeline, name) do
     closed_event = update_duration(event)

--- a/lib/ex_debug_toolbar/data/timeline/event.ex
+++ b/lib/ex_debug_toolbar/data/timeline/event.ex
@@ -2,7 +2,7 @@ defmodule ExDebugToolbar.Data.Timeline.Event do
   defstruct [
     name: nil,
     started_at: nil,
-    duration: nil,
-    events: nil,
+    duration: 0,
+    events: [],
   ]
 end

--- a/lib/ex_debug_toolbar/data/timeline/event.ex
+++ b/lib/ex_debug_toolbar/data/timeline/event.ex
@@ -2,6 +2,7 @@ defmodule ExDebugToolbar.Data.Timeline.Event do
   defstruct [
     name: nil,
     started_at: nil,
-    duration: nil
+    duration: nil,
+    events: nil,
   ]
 end

--- a/test/lib/ex_debug_toolbar/data/timeline_test.exs
+++ b/test/lib/ex_debug_toolbar/data/timeline_test.exs
@@ -19,18 +19,27 @@ defmodule ExDebugToolbar.Data.TimelineTest do
   test "accepts nested events" do
     timeline =
       %Timeline{}
-      |> Timeline.start_event("outsider")
-      |> Timeline.start_event("nested")
-      |> Timeline.finish_event("nested")
-      |> Timeline.finish_event("outsider")
+      |> Timeline.start_event("A")
+      |> Timeline.start_event("B")
+      |> Timeline.finish_event("B")
+      |> Timeline.start_event("B")
+      |> Timeline.finish_event("B")
+      |> Timeline.finish_event("A")
+      |> Timeline.start_event("C")
+      |> Timeline.start_event("D")
+      |> Timeline.finish_event("D")
+      |> Timeline.start_event("E")
+      |> Timeline.finish_event("E")
+      |> Timeline.finish_event("C")
 
-    assert timeline.events |> length == 1
-    outsider_event = timeline.events |> List.first
-    assert %Event{name: "outsider"} = outsider_event
+    [first_event, second_event] = timeline.events
+    assert first_event.name == "C"
+    assert first_event.events |> Enum.at(0) |> Map.fetch!(:name) == "E"
+    assert first_event.events |> Enum.at(1) |> Map.fetch!(:name) == "D"
 
-    assert outsider_event.events |> length == 1
-    nested_event = outsider_event.events |> List.first
-    assert %Event{name: "nested"} = nested_event
+    assert second_event.name == "A"
+    assert second_event.events |> Enum.at(0) |> Map.fetch!(:name) == "B"
+    assert second_event.events |> Enum.at(1) |> Map.fetch!(:name) == "B"
   end
 
   test "raises an error when closing an event that is not open" do

--- a/test/lib/ex_debug_toolbar/data/timeline_test.exs
+++ b/test/lib/ex_debug_toolbar/data/timeline_test.exs
@@ -42,13 +42,20 @@ defmodule ExDebugToolbar.Data.TimelineTest do
 
   describe "duration/1" do
     test "retuns total duration of all events" do
-      timeline = %Timeline{events: [%Event{duration: 5}, %Event{duration: 1}]}
-      assert timeline |> Timeline.duration == 6
+      timeline =
+        %Timeline{}
+        |> Timeline.start_event("outsider")
+        |> Timeline.finish_event("nested")
+        |> Timeline.start_event("nested")
+        |> Timeline.finish_event("outsider")
+      assert Timeline.duration(timeline) == Enum.reduce(timeline.events, 0, fn(e, acc) -> acc + e.duration end)
     end
 
     test "it ignores unfinished events" do
-      timeline = %Timeline{events: [%Event{duration: 5}, %Event{}]}
-      assert timeline |> Timeline.duration == 5
+      timeline =
+        %Timeline{}
+        |> Timeline.start_event("outsider")
+      assert timeline |> Timeline.duration == 0
     end
   end
 end

--- a/test/lib/ex_debug_toolbar/data/timeline_test.exs
+++ b/test/lib/ex_debug_toolbar/data/timeline_test.exs
@@ -33,11 +33,18 @@ defmodule ExDebugToolbar.Data.TimelineTest do
     assert %Event{name: "nested"} = nested_event
   end
 
-  test "raises unless name matches" do
-    # todo
-  end
-
-  test "raises if timeline has no events" do
+  test "raises an error when closing an event that is not open" do
+    assert_raise RuntimeError, fn ->
+      %Timeline{}
+      |> Timeline.start_event("outsider")
+      |> Timeline.finish_event("nested")
+    end
+    assert_raise RuntimeError, fn ->
+      %Timeline{}
+      |> Timeline.start_event("outsider")
+      |> Timeline.start_event("another")
+      |> Timeline.finish_event("nested")
+    end
   end
 
   describe "duration/1" do
@@ -45,9 +52,9 @@ defmodule ExDebugToolbar.Data.TimelineTest do
       timeline =
         %Timeline{}
         |> Timeline.start_event("outsider")
-        |> Timeline.finish_event("nested")
-        |> Timeline.start_event("nested")
         |> Timeline.finish_event("outsider")
+        |> Timeline.start_event("nested")
+        |> Timeline.finish_event("nested")
       assert Timeline.duration(timeline) == Enum.reduce(timeline.events, 0, fn(e, acc) -> acc + e.duration end)
     end
 


### PR DESCRIPTION
Do we want to keep 2 different timings for each event?
as in
1. Total time (end_time - start_time)
2. nested events time (as in, the sum of all the nested events)

### todo
- [x] Validate that the name of the closing event is the same as the last event in the queue. raise if not
- [x] Add some more test cases with mixture of nested and same level events
- [ ] Check possible refactor to replace `events:` in timeline with a single Event struct.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/7)
<!-- Reviewable:end -->
