### PR TITLE
support provided finish event with a precalculated duration value to

### DIFF
--- a/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
+++ b/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
@@ -6,10 +6,6 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollector do
     Toolbar.start_event("request")
   end
   def ex_debug_toolbar(:stop, time_diff, _) do
-    Toolbar.finish_event("request", duration: to_microseconds(time_diff))
-  end
-
-  defp to_microseconds(native_time) do
-    System.convert_time_unit(native_time, :native, :microsecond)
+    Toolbar.finish_event("request", duration: time_diff)
   end
 end

--- a/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
+++ b/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
@@ -14,18 +14,16 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollector do
     Toolbar.start_event(event_name)
     event_name
   end
- 
-  def phoenix_controller_call(:stop, _diff, event_name) do
-    Toolbar.finish_event(event_name)
+  def phoenix_controller_call(:stop, time_diff, event_name) do
+    Toolbar.finish_event(event_name, duration: time_diff)
   end
- 
+
   def phoenix_controller_render(:start, _, %{template: template}) do
     Toolbar.start_event(template)
     template
   end
- 
-  def phoenix_controller_render(:stop, _diff, template) do
-    Toolbar.finish_event(template)
+  def phoenix_controller_render(:stop, time_diff, template) do
+    Toolbar.finish_event(template, duration: time_diff)
   end
 
   defp controller_event_name(%{private: %{phoenix_controller: controller, phoenix_action: action}}) do

--- a/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
+++ b/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
@@ -5,7 +5,11 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollector do
     Toolbar.start_request
     Toolbar.start_event("request")
   end
-  def ex_debug_toolbar(:stop, _, _) do
-    Toolbar.finish_event("request")
+  def ex_debug_toolbar(:stop, time_diff, _) do
+    Toolbar.finish_event("request", duration: to_microseconds(time_diff))
+  end
+
+  defp to_microseconds(native_time) do
+    System.convert_time_unit(native_time, :native, :microsecond)
   end
 end

--- a/lib/ex_debug_toolbar/data/timeline.ex
+++ b/lib/ex_debug_toolbar/data/timeline.ex
@@ -8,7 +8,7 @@ defmodule ExDebugToolbar.Data.Timeline do
   ]
 
   def start_event(%Timeline{} = timeline, name) do
-    event = %Timeline.Event{name: name, started_at: DateTime.utc_now()}
+    event = %Timeline.Event{name: name, started_at: System.monotonic_time()}
     %{timeline | queue: [event | timeline.queue]}
   end
 
@@ -30,8 +30,7 @@ defmodule ExDebugToolbar.Data.Timeline do
   def finish_event(_timeline, name, _opts), do: raise "the event #{name} is not open"
 
   defp update_duration(event, nil) do
-    finished_at = DateTime.utc_now
-    duration = DateTime.to_unix(finished_at, :microsecond) - DateTime.to_unix(event.started_at, :microsecond)
+    duration = System.monotonic_time() - event.started_at
     update_duration(event, duration)
   end
   defp update_duration(event, duration), do: %{event | duration: duration}

--- a/lib/ex_debug_toolbar/data/timeline.ex
+++ b/lib/ex_debug_toolbar/data/timeline.ex
@@ -12,27 +12,29 @@ defmodule ExDebugToolbar.Data.Timeline do
     %{timeline | queue: [event | timeline.queue]}
   end
 
-  def finish_event(%Timeline{queue: [%{name: name} = event]} = timeline, name) do
+  def finish_event(timeline, name, opts \\ [])
+  def finish_event(%Timeline{queue: [%{name: name} = event]} = timeline, name, opts) do
     events = timeline.events
-    finished_event = update_duration(event)
+    finished_event = update_duration(event, opts[:duration])
     %{timeline |
       queue: [],
       events: [finished_event | events],
       duration: finished_event.duration + timeline.duration
     }
   end
-  def finish_event(%Timeline{queue: [%{name: name} = event | [parent | rest]]} = timeline, name) do
-    finished_event = update_duration(event)
+  def finish_event(%Timeline{queue: [%{name: name} = event | [parent | rest]]} = timeline, name, opts) do
+    finished_event = update_duration(event, opts[:duration])
     new_parent = %{parent | events: [finished_event | parent.events]}
     %{timeline | queue: [new_parent | rest]}
   end
-  def finish_event(_timeline, name), do: raise "the event #{name} is not open"
+  def finish_event(_timeline, name, _opts), do: raise "the event #{name} is not open"
 
-  defp update_duration(event) do
+  defp update_duration(event, nil) do
     finished_at = DateTime.utc_now
     duration = DateTime.to_unix(finished_at, :microsecond) - DateTime.to_unix(event.started_at, :microsecond)
-    %{event | duration: duration}
+    update_duration(event, duration)
   end
+  defp update_duration(event, duration), do: %{event | duration: duration}
 end
 
 alias ExDebugToolbar.Data.{Collection, Timeline, Timeline.Action}
@@ -42,7 +44,7 @@ defimpl Collection, for: Timeline do
     Timeline.start_event(timeline, name)
   end
 
-  def change(timeline, %Action{action: :finish_event, event_name: name}) do
-    Timeline.finish_event(timeline, name)
+  def change(timeline, %Action{action: :finish_event, event_name: name, duration: duration}) do
+    Timeline.finish_event(timeline, name, duration: duration)
   end
 end

--- a/lib/ex_debug_toolbar/data/timeline/action.ex
+++ b/lib/ex_debug_toolbar/data/timeline/action.ex
@@ -1,5 +1,5 @@
 defmodule ExDebugToolbar.Data.Timeline.Action do
-  defstruct [:action, :event_name]
+  defstruct [:action, :event_name, :duration]
 end
 alias ExDebugToolbar.Data.{Collectable, Timeline.Action, Timeline}
 

--- a/lib/ex_debug_toolbar/request.ex
+++ b/lib/ex_debug_toolbar/request.ex
@@ -1,6 +1,7 @@
 defmodule ExDebugToolbar.Request do
   defstruct [
     id: nil,
+    created_at: nil,
     data: %{}
   ]
 end

--- a/lib/ex_debug_toolbar/toolbar.ex
+++ b/lib/ex_debug_toolbar/toolbar.ex
@@ -17,8 +17,12 @@ defmodule ExDebugToolbar.Toolbar do
     add_data(:timeline, %Timeline.Action{action: :start_event, event_name: name})
   end
 
-  def finish_event(name) do
-    add_data(:timeline, %Timeline.Action{action: :finish_event, event_name: name})
+  def finish_event(name, opts \\ []) do
+    add_data(:timeline, %Timeline.Action{
+       action: :finish_event,
+       event_name: name,
+       duration: opts[:duration]
+     })
   end
 
   def record_event(name, func) do

--- a/lib/ex_debug_toolbar/toolbar.ex
+++ b/lib/ex_debug_toolbar/toolbar.ex
@@ -4,7 +4,7 @@ defmodule ExDebugToolbar.Toolbar do
   alias ExDebugToolbar.Data.{Collectable, Collection, Timeline}
 
   def start_request do
-    request = %Request{id: get_request_id()}
+    request = %Request{id: get_request_id(), created_at: NaiveDateTime.utc_now()}
     :ok = Registry.register(request)
   end
 

--- a/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
+++ b/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
@@ -19,6 +19,7 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollectorTest do
     test "it starts request on ex_debug_toolbar start" do
       Collector.ex_debug_toolbar(:start, %{}, %{})
       assert {:ok, request} = get_request(@request_id)
+      assert %NaiveDateTime{} = request.created_at
       assert request.data.timeline
     end
 
@@ -27,7 +28,7 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollectorTest do
       Collector.ex_debug_toolbar(:stop, 50000, %{})
       assert {:ok, request} = get_request(@request_id)
       assert request.data.timeline.events |> Enum.any?
-      assert request.data.timeline.duration == 50
+      assert request.data.timeline.duration == 50000
     end
   end
 end

--- a/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
+++ b/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
@@ -24,10 +24,10 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollectorTest do
 
     test "it records request timeline on stop" do
       Collector.ex_debug_toolbar(:start, %{}, %{})
-      Collector.ex_debug_toolbar(:stop, %{}, %{})
+      Collector.ex_debug_toolbar(:stop, 50000, %{})
       assert {:ok, request} = get_request(@request_id)
       assert request.data.timeline.events |> Enum.any?
-      assert request.data.timeline.duration > 0
+      assert request.data.timeline.duration == 50
     end
   end
 end

--- a/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
+++ b/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
@@ -39,9 +39,11 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollectorTest do
 
     test "it records a phoenix controller event" do
       conn = %{private: %{phoenix_controller: ExDebugToolbar.Toolbar , phoenix_action: "execute"}}
-      call_collector(&Collector.phoenix_controller_call/3, context: %{conn: conn})
+      call_collector(&Collector.phoenix_controller_call/3, context: %{conn: conn}, duration: 19)
       assert {:ok, request} = get_request(@request_id)
-      assert find_event(request.data.timeline, "ExDebugToolbar.Toolbar:execute")
+      event = find_event(request.data.timeline, "ExDebugToolbar.Toolbar:execute")
+      assert event
+      assert event.duration == 19
     end
   end
 
@@ -49,9 +51,11 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollectorTest do
     setup [:start_request]
 
     test "it records a phoenix render event" do
-      call_collector(&Collector.phoenix_controller_render/3, context: %{template: "template"})
+      call_collector(&Collector.phoenix_controller_render/3, context: %{template: "template"}, duration: 7)
       assert {:ok, request} = get_request(@request_id)
-      assert find_event(request.data.timeline, "template")
+      event = find_event(request.data.timeline, "template")
+      assert event
+      assert event.duration == 7
     end
   end
 

--- a/test/lib/ex_debug_toolbar/data/timeline_test.exs
+++ b/test/lib/ex_debug_toolbar/data/timeline_test.exs
@@ -66,9 +66,9 @@ defmodule ExDebugToolbar.Data.TimelineTest do
   end
 
   test "optionally accepts precalculated event duration" do
-    timeline = %Timeline{} |> Timeline.start_event("A")
-    :timer.sleep 50
-    timeline = timeline |> Timeline.finish_event("A", duration: 19)
-    assert timeline.duration == 19
+    timeline = %Timeline{}
+    |> Timeline.start_event("A")
+    |> Timeline.finish_event("A", duration: 1000)
+    assert timeline.duration == 1000
   end
 end

--- a/test/lib/ex_debug_toolbar/data/timeline_test.exs
+++ b/test/lib/ex_debug_toolbar/data/timeline_test.exs
@@ -64,4 +64,11 @@ defmodule ExDebugToolbar.Data.TimelineTest do
       |> Timeline.finish_event("A")
     end
   end
+
+  test "optionally accepts precalculated event duration" do
+    timeline = %Timeline{} |> Timeline.start_event("A")
+    :timer.sleep 50
+    timeline = timeline |> Timeline.finish_event("A", duration: 19)
+    assert timeline.duration == 19
+  end
 end

--- a/test/lib/ex_debug_toolbar/data/timeline_test.exs
+++ b/test/lib/ex_debug_toolbar/data/timeline_test.exs
@@ -12,7 +12,9 @@ defmodule ExDebugToolbar.Data.TimelineTest do
     assert timeline.events |> length == 1
     event = timeline.events |> List.first
 
-    assert %Event{name: "name", started_at: %DateTime{}} = event
+    assert %Event{} = event
+    assert event.name == "name"
+    assert is_integer(event.started_at)
     assert event.duration > 0
   end
 


### PR DESCRIPTION
improve prevision of reports that return time difference, such as
phoenix instrumentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/12)
<!-- Reviewable:end -->
