### PR TITLE
Feature/conn collector

### DIFF
--- a/lib/ex_debug_toolbar/collector/conn_collector.ex
+++ b/lib/ex_debug_toolbar/collector/conn_collector.ex
@@ -1,0 +1,15 @@
+defmodule ExDebugToolbar.Collector.ConnCollector do
+  alias ExDebugToolbar.Toolbar
+
+  @behaviour Plug
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{} = conn, _opts) do
+    Toolbar.add_data(:conn, {:request, conn})
+    Plug.Conn.register_before_send(conn, fn conn ->
+      Toolbar.add_data(:conn, {:response, conn})
+      conn
+    end)
+  end
+end

--- a/lib/ex_debug_toolbar/collector/logger_collector.ex
+++ b/lib/ex_debug_toolbar/collector/logger_collector.ex
@@ -1,6 +1,6 @@
 defmodule ExDebugToolbar.Collector.LoggerCollector do
   alias ExDebugToolbar.Toolbar
-  alias ExDebugToolbar.Data.LogEntry
+  alias ExDebugToolbar.Data.Logs.Entry
   @behaviour :gen_event
 
   def init(_), do: {:ok, nil}
@@ -36,7 +36,7 @@ defmodule ExDebugToolbar.Collector.LoggerCollector do
 
   defp add_log_to_toolbar(level, event) do
     {Logger, message, timestamp, metadata} = event
-    log_entry = %LogEntry{
+    log_entry = %Entry{
       level: level,
       message: message,
       timestamp: timestamp

--- a/lib/ex_debug_toolbar/data/conn.ex
+++ b/lib/ex_debug_toolbar/data/conn.ex
@@ -1,33 +1,31 @@
 defmodule ExDebugToolbar.Data.Conn do
-  defstruct ~w(
-    host method script_name request_path port remote_ip scheme
-    query_string body_params query_params path_params req_cookies req_headers
-    status resp_charset assigns resp_cookies resp_headers
-  )a
-end
-alias ExDebugToolbar.Data.{Collection, Conn}
-
-defimpl Collection, for: Conn do
-
   @request_keys ~w(
     host method script_name request_path port remote_ip scheme
     query_string body_params query_params path_params req_cookies req_headers
   )a
-
   @response_keys ~w(status resp_charset assigns resp_cookies resp_headers)a
 
+  defstruct @request_keys ++ @response_keys
+
+  def request_keys, do: @request_keys
+  def response_keys, do: @response_keys
+end
+
+alias ExDebugToolbar.Data.{Collection, Conn}
+
+defimpl Collection, for: Conn do
   def add(collection, changes) when is_map(changes) do
     Map.merge(collection, changes)
   end
 
   def format_item(_collection, {:request, %Plug.Conn{} = conn}) do
     conn
-    |> Map.take(@request_keys)
+    |> Map.take(Conn.request_keys())
     |> Map.update!(:remote_ip, &format_ip/1)
   end
 
   def format_item(_collection, {:response, %Plug.Conn{} = conn}) do
-    conn |> Map.take(@response_keys)
+    conn |> Map.take(Conn.response_keys())
   end
 
   defp format_ip(nil), do: nil

--- a/lib/ex_debug_toolbar/data/conn.ex
+++ b/lib/ex_debug_toolbar/data/conn.ex
@@ -1,0 +1,37 @@
+defmodule ExDebugToolbar.Data.Conn do
+  defstruct ~w(
+    host method script_name request_path port remote_ip scheme
+    query_string body_params query_params path_params req_cookies req_headers
+    status resp_charset assigns resp_cookies resp_headers
+  )a
+end
+alias ExDebugToolbar.Data.{Collection, Conn}
+
+defimpl Collection, for: Conn do
+
+  @request_keys ~w(
+    host method script_name request_path port remote_ip scheme
+    query_string body_params query_params path_params req_cookies req_headers
+  )a
+
+  @response_keys ~w(status resp_charset assigns resp_cookies resp_headers)a
+
+  def add(collection, changes) when is_map(changes) do
+    Map.merge(collection, changes)
+  end
+
+  def format_item(_collection, {:request, %Plug.Conn{} = conn}) do
+    conn
+    |> Map.take(@request_keys)
+    |> Map.update!(:remote_ip, &format_ip/1)
+  end
+
+  def format_item(_collection, {:response, %Plug.Conn{} = conn}) do
+    conn |> Map.take(@response_keys)
+  end
+
+  defp format_ip(nil), do: nil
+  defp format_ip(ip_tuple) do
+    ip_tuple |> Tuple.to_list |> Enum.join(".")
+  end
+end

--- a/lib/ex_debug_toolbar/data/log_entry.ex
+++ b/lib/ex_debug_toolbar/data/log_entry.ex
@@ -1,7 +1,0 @@
-defmodule ExDebugToolbar.Data.LogEntry do
-  defstruct [
-    level: nil,
-    message: nil,
-    timestamp: nil
-  ]
-end

--- a/lib/ex_debug_toolbar/data/logs.ex
+++ b/lib/ex_debug_toolbar/data/logs.ex
@@ -1,15 +1,19 @@
 defmodule ExDebugToolbar.Data.Logs do
+  defmodule Entry do
+    defstruct ~w(level message timestamp)a
+  end
+
   defstruct [entries: []]
 end
 
-alias ExDebugToolbar.Data.{Collection, Logs, LogEntry}
+alias ExDebugToolbar.Data.{Collection, Logs}
 
 defimpl Collection, for: Logs do
   def add(collection, entry) when is_map(entry) do
     Map.update!(collection, :entries, &([entry | &1]))
   end
 
-  def format_item(_collection, %LogEntry{} = entry) do
+  def format_item(_collection, %Logs.Entry{} = entry) do
     entry
     |> Map.from_struct
     |> Map.update!(:message, &to_string/1)

--- a/lib/ex_debug_toolbar/data/timeline.ex
+++ b/lib/ex_debug_toolbar/data/timeline.ex
@@ -1,6 +1,15 @@
 defmodule ExDebugToolbar.Data.Timeline do
   alias ExDebugToolbar.Data.Timeline
 
+  defmodule Event do
+    defstruct [
+      name: nil,
+      started_at: nil,
+      duration: 0,
+      events: [],
+    ]
+  end
+
   defstruct [
     events: [],
     duration: 0,

--- a/lib/ex_debug_toolbar/data/timeline/event.ex
+++ b/lib/ex_debug_toolbar/data/timeline/event.ex
@@ -1,8 +1,0 @@
-defmodule ExDebugToolbar.Data.Timeline.Event do
-  defstruct [
-    name: nil,
-    started_at: nil,
-    duration: 0,
-    events: [],
-  ]
-end

--- a/lib/ex_debug_toolbar/plug/pipeline.ex
+++ b/lib/ex_debug_toolbar/plug/pipeline.ex
@@ -3,4 +3,5 @@ defmodule ExDebugToolbar.Plug.Pipeline do
 
   plug ExDebugToolbar.Plug.RequestId
   plug ExDebugToolbar.Plug.CodeInjector
+  plug ExDebugToolbar.Collector.ConnCollector
 end

--- a/lib/ex_debug_toolbar/poison/encoder/tuple.ex
+++ b/lib/ex_debug_toolbar/poison/encoder/tuple.ex
@@ -1,0 +1,5 @@
+defimpl Poison.Encoder, for: Tuple do
+  def encode(tuple, options) do
+    tuple |> Tuple.to_list |> Poison.Encoder.encode(options)
+  end
+end

--- a/lib/ex_debug_toolbar/toolbar/config.ex
+++ b/lib/ex_debug_toolbar/toolbar/config.ex
@@ -1,11 +1,12 @@
 defmodule ExDebugToolbar.Toolbar.Config do
-  alias ExDebugToolbar.Data.{Timeline, Logs, EctoQueries}
+  alias ExDebugToolbar.Data.{Conn, Timeline, Logs, EctoQueries}
 
   @default_config %{
     collections: %{
+      conn: %Conn{},
       ecto: %EctoQueries{},
       logs: %Logs{},
-      timeline: %Timeline{}
+      timeline: %Timeline{},
     }
   }
 

--- a/test/lib/ex_debug_toolbar/collector/conn_collector_test.exs
+++ b/test/lib/ex_debug_toolbar/collector/conn_collector_test.exs
@@ -1,0 +1,13 @@
+defmodule ExDebugToolbar.Collector.ConnCollectorTest do
+  use ExDebugToolbar.CollectorCase, async: false
+  alias ExDebugToolbar.Collector.ConnCollector, as: Collector
+
+  setup :start_request
+
+  test "it collects conn data" do
+    %Plug.Conn{request_path: "/path"} |> Collector.call(%{})
+    assert {:ok, request} = get_request()
+    assert request.data |> Map.has_key?(:conn)
+    assert %{request_path: "/path"} = request.data.conn
+  end
+end

--- a/test/lib/ex_debug_toolbar/data/conn_test.exs
+++ b/test/lib/ex_debug_toolbar/data/conn_test.exs
@@ -1,0 +1,33 @@
+defmodule ExDebugToolbar.Data.ConnTest do
+  use ExUnit.Case, async: true
+  alias ExDebugToolbar.Data.{Collection, Conn}
+
+  describe "collection protocol" do
+    setup do
+      conn = %Plug.Conn{
+      }
+      {:ok, conn: conn}
+    end
+
+    test "format_item/2 formats ip on request" do
+      conn = %Plug.Conn{remote_ip: {127, 0, 0, 1}}
+      assert %{remote_ip: "127.0.0.1"} = Collection.format_item(%Conn{}, {:request, conn})
+    end
+
+    test "format_item/2 handles empty ip on request" do
+      conn = %Plug.Conn{remote_ip: nil}
+      assert %{remote_ip: nil} = Collection.format_item(%Conn{}, {:request, conn})
+    end
+
+    test "format_item/2 takes req_headers on request" do
+      conn = %Plug.Conn{req_headers: [{:foo, :bar}]}
+      assert %{req_headers: [{:foo, :bar}]} = Collection.format_item(%Conn{}, {:request, conn})
+    end
+
+    test "format_item/2 takes resp_headers on response" do
+      conn = %Plug.Conn{resp_headers: [{:foo, :bar}]}
+      assert %{resp_headers: [{:foo, :bar}]} = Collection.format_item(%Conn{}, {:response, conn})
+    end
+  end
+end
+

--- a/test/lib/ex_debug_toolbar/data/logs_test.exs
+++ b/test/lib/ex_debug_toolbar/data/logs_test.exs
@@ -1,10 +1,10 @@
 defmodule ExDebugToolbar.Data.LogsTest do
   use ExUnit.Case, async: true
-  alias ExDebugToolbar.Data.{Collection, LogEntry, Logs}
+  alias ExDebugToolbar.Data.{Collection, Logs}
 
   describe "collection protocol" do
     setup do
-      entry = %LogEntry{
+      entry = %Logs.Entry{
         level: "debug",
         message: "hey",
         timestamp: {{2015, 4, 29}, {2, 44, 0, 0}}

--- a/test/lib/ex_debug_toolbar/poison/encoder/tuple_test.exs
+++ b/test/lib/ex_debug_toolbar/poison/encoder/tuple_test.exs
@@ -4,7 +4,7 @@ defmodule ExDebugToolbar.Poison.Encoder.TupleTest do
 
   describe "Poison.Encoder protocol" do
     test "tuples are encoded as lists" do
-      assert Encoder.encode({:foo, :bar}, []) |> to_string == "[\"foo\",\"bar\"]"
+      assert Encoder.encode({:foo, :bar}, []) |> to_string == ~S(["foo","bar"])
     end
   end
 end

--- a/test/lib/ex_debug_toolbar/poison/encoder/tuple_test.exs
+++ b/test/lib/ex_debug_toolbar/poison/encoder/tuple_test.exs
@@ -1,0 +1,10 @@
+defmodule ExDebugToolbar.Poison.Encoder.TupleTest do
+  use ExUnit.Case, async: true
+  alias Poison.Encoder
+
+  describe "Poison.Encoder protocol" do
+    test "tuples are encoded as lists" do
+      assert Encoder.encode({:foo, :bar}, []) |> to_string == "[\"foo\",\"bar\"]"
+    end
+  end
+end

--- a/test/lib/ex_debug_toolbar/toolbar/config_test.exs
+++ b/test/lib/ex_debug_toolbar/toolbar/config_test.exs
@@ -1,7 +1,7 @@
 defmodule ExDebugToolbar.Toolbar.ConfigTest do
   use ExUnit.Case, async: false
 
-  alias ExDebugToolbar.Data.{Timeline, Logs, EctoQueries}
+  alias ExDebugToolbar.Data.{Conn, Timeline, Logs, EctoQueries}
   alias ExDebugToolbar.Toolbar.Config
 
   setup do
@@ -12,9 +12,10 @@ defmodule ExDebugToolbar.Toolbar.ConfigTest do
 
   test "get_collections/0 returns default collections definitions" do
     assert Config.get_collections() == %{
+      conn: %Conn{},
       logs: %Logs{},
       timeline: %Timeline{},
-      ecto: %EctoQueries{}
+      ecto: %EctoQueries{},
     }
   end
 


### PR DESCRIPTION
I'm questioning if collectors is not the right way to group these modules. They all have different roles: plug, logger backend, ecto logger, template engine. Would it make more sense to name these modules after those roles instead of having them all under collectors? On the other hand, it makes it simpler to maintain all of them, you don't have to know what roles each collector has in it's app to find it in our codebase.

@epilgrim what do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/19)
<!-- Reviewable:end -->
