### PR TITLE
as a default it doesn't makes sense to track outter request time as it

### DIFF
--- a/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
+++ b/lib/ex_debug_toolbar/collector/instrumentation_collector.ex
@@ -3,11 +3,8 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollector do
 
   def ex_debug_toolbar(:start, _, _) do
     Toolbar.start_request
-    Toolbar.start_event("request")
   end
-  def ex_debug_toolbar(:stop, time_diff, _) do
-    Toolbar.finish_event("request", duration: time_diff)
-  end
+  def ex_debug_toolbar(:stop, _, _), do: :ok
 
   def phoenix_controller_call(:start, _, %{conn: conn}) do
     event_name = controller_event_name(conn)

--- a/test/fixtures/endpoint.ex
+++ b/test/fixtures/endpoint.ex
@@ -3,21 +3,24 @@ defmodule ExDebugToolbar.Fixtures.Endpoint do
   use ExDebugToolbar.Phoenix
   require Logger
   import Plug.Conn
+  alias ExDebugToolbar.Toolbar
 
   plug Plug.RequestId
 
 
-  plug :dummy_plug
+  plug :tracked_plug
 
-  def dummy_plug(conn, _) do
-    Logger.debug "log entry"
-    conn = conn
-    |> Plug.Conn.assign(:called?, true)
-    |> put_resp_content_type("text/html")
-    |> send_resp(200, "<html><body></body></html>")
-    if timeout = conn.assigns[:timeout] do
-      :timer.sleep timeout
+  def tracked_plug(conn, _) do
+    Toolbar.record_event "test_request", fn ->
+      Logger.debug "log entry"
+      conn = conn
+      |> Plug.Conn.assign(:called?, true)
+      |> put_resp_content_type("text/html")
+      |> send_resp(200, "<html><body></body></html>")
+      if timeout = conn.assigns[:timeout] do
+        :timer.sleep timeout
+      end
+      conn
     end
-    conn
   end
 end

--- a/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
+++ b/test/lib/ex_debug_toolbar/collector/instrumentation_collector_test.exs
@@ -7,14 +7,6 @@ defmodule ExDebugToolbar.Collector.InstrumentationCollectorTest do
       Collector.ex_debug_toolbar(:start, %{}, %{})
       assert {:ok, request} = get_request(@request_id)
       assert %NaiveDateTime{} = request.created_at
-      assert request.data.timeline
-    end
-
-    test "it records request timeline on stop" do
-      call_collector(&Collector.ex_debug_toolbar/3, duration: 50000)
-      assert {:ok, request} = get_request(@request_id)
-      assert request.data.timeline.events |> Enum.any?
-      assert request.data.timeline.duration == 50000
     end
   end
 


### PR DESCRIPTION
inludes things like code reloading

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/21)
<!-- Reviewable:end -->
