### PR TITLE
Correct indentation of code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ A click on any breakpoint will take you to familiar `iex` session with context a
 
 # Installation
   1. Add `ex_debug_toolbar` to your list of dependencies in `mix.exs`:
-
-    ```elixir
-    def deps do
-      [{:ex_debug_toolbar, "~> 0.2.0"}]
-    end
-    ```
+  
+   ```elixir
+   def deps do
+     [{:ex_debug_toolbar, "~> 0.2.0"}]
+   end
+   ```
 
   2. Ensure `:ex_debug_toolbar` is started before your application:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A click on any breakpoint will take you to familiar `iex` session with context a
 
 # Installation
   1. Add `ex_debug_toolbar` to your list of dependencies in `mix.exs`:
-  
+
    ```elixir
    def deps do
      [{:ex_debug_toolbar, "~> 0.2.0"}]


### PR DESCRIPTION
Changed indentation of code so it is shown with syntax highlighting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/28)
<!-- Reviewable:end -->
