### PR TITLE
correct defaults when layout is not assigned

### DIFF
--- a/test/views/toolbar_view_test.exs
+++ b/test/views/toolbar_view_test.exs
@@ -5,8 +5,9 @@ defmodule ExDebugToolbar.ToolbarViewTest do
   alias Phoenix.View
   alias ExDebugToolbar.ToolbarView
   alias ExDebugToolbar.Breakpoint
+  alias Plug.Conn
 
-  test "it renderns toolbar without errors" do
+  test "it renders toolbar without errors" do
     assert %Request{} |> render |> is_bitstring
   end
 
@@ -86,6 +87,10 @@ defmodule ExDebugToolbar.ToolbarViewTest do
       inserted_at: NaiveDateTime.utc_now
     }
     assert %Request{} |> render(breakpoints: [breakpoint]) |> is_bitstring
+  end
+
+  test "it renders toolbar when conn has no layout" do
+    assert %Request{conn: %Conn{assigns: %{layout: false}}} |> render |> is_bitstring
   end
 
   defp render(request, opts \\ []) do

--- a/web/views/toolbar_view.ex
+++ b/web/views/toolbar_view.ex
@@ -50,7 +50,10 @@ defmodule ExDebugToolbar.ToolbarView do
 
   def conn_details(%Plug.Conn{} = conn) do
     conn = conn_with_defaults(conn)
-    {layout_view, layout_template} = conn.assigns.layout
+    {layout_view, layout_template} = case conn.assigns.layout do
+      false -> @default_conn.assigns.layout
+      layout -> layout
+    end
     [
       "Endpoint": conn.private.phoenix_endpoint,
       "Controller": get_controller(conn),


### PR DESCRIPTION
Default value when no template available is false. Therefore, the current way of assigning defaults to connection doesn't apply, as there is always a key `:layout`

not sure the best approach here.
1. Current PR, where the simplest patch is applied, and we wait until further cases like this to decide
2. Remove :assigns from the @defaults_conn, as the only case does not apply, keep PR change
3. Add new "cleanup" step, where we more smartly remove defaults like layout

WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/29)
<!-- Reviewable:end -->
