### PR TITLE
Feature/error pages

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@ config :ex_debug_toolbar,
   remove_glob_params: true
 
 config :ex_debug_toolbar, ExDebugToolbar.Fixtures.Endpoint,
-  instrumenters: [ExDebugToolbar.Collector.InstrumentationCollector]
+  instrumenters: [ExDebugToolbar.Collector.InstrumentationCollector],
+  debug_errors: true
 
 config :ex_debug_toolbar, ExDebugToolbar.Endpoint,
   url: [host: "localhost"],

--- a/lib/ex_debug_toolbar/plug/code_injector.ex
+++ b/lib/ex_debug_toolbar/plug/code_injector.ex
@@ -47,7 +47,7 @@ defmodule ExDebugToolbar.Plug.CodeInjector do
   end
 
   defp inject?(%Conn{request_path: "/phoenix/live_reload/frame"}), do: false
-  defp inject?(%Conn{status: status}) when not status in [200, 404], do: false
+  defp inject?(%Conn{status: status}) when status >= 300 and status < 400, do: false
   defp inject?(%Conn{} = conn), do: html_content_type?(conn)
 
   defp html_content_type?(%Conn{} = conn) do

--- a/test/lib/ex_debug_toolbar/phoenix_test.exs
+++ b/test/lib/ex_debug_toolbar/phoenix_test.exs
@@ -29,7 +29,7 @@ defmodule ExDebugToolbar.PhoenixTest do
     assert request.timeline.duration > 70 * 1000 # not sure why
   end
 
-  test "it creates request on 404 errors" do
+  test "it creates request and injects toolbar on 404 errors" do
     conn = make_request "/", error: :no_route
     assert {:ok, request} = get_request()
     assert request.stopped?
@@ -38,13 +38,12 @@ defmodule ExDebugToolbar.PhoenixTest do
     assert Regex.match? ~r/src=['"].*?toolbar.js['"]/, body
   end
 
-  test "it creates request on 500 errors" do
+  test "it creates request and injects toolbar on 500 errors" do
     {_, _, body} = assert_error_sent 500, fn ->
       make_request "/", error: :exception
     end
     assert {:ok, request} = get_request()
     assert request.stopped?
-    # IO.puts body
     # cannot use simple String.contains/2 as it appears in code snippet and matches
     assert Regex.match? ~r/src=['"].*?toolbar.js['"]/, body
   end

--- a/test/lib/ex_debug_toolbar/phoenix_test.exs
+++ b/test/lib/ex_debug_toolbar/phoenix_test.exs
@@ -1,6 +1,7 @@
 defmodule ExDebugToolbar.PhoenixTest do
   use ExUnit.Case, async: true
   use Plug.Test
+  import Phoenix.ConnTest, only: [assert_error_sent: 2]
   import Supervisor.Spec
   import ExDebugToolbar.Test.Support.RequestHelpers
   alias ExDebugToolbar.Fixtures.Endpoint
@@ -26,6 +27,26 @@ defmodule ExDebugToolbar.PhoenixTest do
     make_request "/", timeout: 100
     assert {:ok, request} = get_request()
     assert request.timeline.duration > 70 * 1000 # not sure why
+  end
+
+  test "it creates request on 404 errors" do
+    conn = make_request "/", error: :no_route
+    assert {:ok, request} = get_request()
+    assert request.stopped?
+    assert {404, _, body} = sent_resp(conn)
+    # cannot use simple String.contains/2 as it appears in code snippet and matches
+    assert Regex.match? ~r/src=['"].*?toolbar.js['"]/, body
+  end
+
+  test "it creates request on 500 errors" do
+    {_, _, body} = assert_error_sent 500, fn ->
+      make_request "/", error: :exception
+    end
+    assert {:ok, request} = get_request()
+    assert request.stopped?
+    # IO.puts body
+    # cannot use simple String.contains/2 as it appears in code snippet and matches
+    assert Regex.match? ~r/src=['"].*?toolbar.js['"]/, body
   end
 
   test "it closes connection" do
@@ -56,6 +77,7 @@ defmodule ExDebugToolbar.PhoenixTest do
 
   defp make_request(path, assigns \\ %{}) do
     conn(:get, path)
+    |> put_req_header("accept", "text/html")
     |> Map.put(:assigns, Map.new(assigns))
     |> Endpoint.call(%{})
   end

--- a/test/lib/ex_debug_toolbar/plug/code_injector_test.exs
+++ b/test/lib/ex_debug_toolbar/plug/code_injector_test.exs
@@ -16,12 +16,13 @@ defmodule ExDebugToolbar.Plug.CodeInjectorTest do
     assert conn.resp_body == expected_html
   end
 
-  test "it injects when response status is 404" do
+  test "it adds js and css to html of error response" do
     html = "<html><head></head><body></body></html>"
-    conn = conn_with_plug(status: 404, body: html)
     expected_html = "<html><head>#{@css}</head><body>#{@js}</body></html>"
-
-    assert conn.resp_body == expected_html
+    for status <- [400, 404, 406, 500] do
+      conn = conn_with_plug(body: html, status: status)
+      assert conn.resp_body == expected_html
+    end
   end
 
   test "it does nothing if there is no body tag" do
@@ -31,11 +32,12 @@ defmodule ExDebugToolbar.Plug.CodeInjectorTest do
     assert conn.resp_body == html
   end
 
-  test "it does nothing if response status differs from 200 or 404" do
+  test "it does nothing if response is a redirect" do
     html = "<html><head></head><body></body></html>"
-    conn = conn_with_plug(body: html, status: 500)
-
-    assert conn.resp_body == html
+    for status <- [301, 302] do
+      conn = conn_with_plug(body: html, status: status)
+      assert conn.resp_body == html
+    end
   end
 
   test "it does nothing if response is not html" do

--- a/test/views/toolbar_view_test.exs
+++ b/test/views/toolbar_view_test.exs
@@ -75,6 +75,18 @@ defmodule ExDebugToolbar.ToolbarViewTest do
     assert request |> render |> is_bitstring
   end
 
+  test "it renders toolbar with timeline that has controller.call event only" do
+    timeline = %Timeline{
+      duration: 50,
+      events: [%Timeline.Event{
+        name: "controller.call",
+        duration: 5,
+        }]
+    }
+    request = %Request{timeline: timeline}
+    assert request |> render |> is_bitstring
+  end
+
   test "it renders toolbar with breakpoints" do
     breakpoint = %Breakpoint{
       id: 1,

--- a/web/views/toolbar_view.ex
+++ b/web/views/toolbar_view.ex
@@ -99,10 +99,14 @@ defmodule ExDebugToolbar.ToolbarView do
   end
 
   def controller_times(%Timeline{} = timeline) do
-    events = MapSet.new ~w(controller.call controller.render)
-    [call, render] = timeline
+    event_names = MapSet.new ~w(controller.call controller.render)
+    events = timeline
     |> Timeline.get_all_events
-    |> Enum.filter(&MapSet.member?(events, &1.name))
+    |> Enum.filter(&MapSet.member?(event_names, &1.name))
+    {call, render} = case events do
+      [call, render] -> {call, render}
+      [call] -> {call, %Timeline.Event{}}
+    end
     [
       "Controller": call.duration - render.duration,
       "Templates": render.duration,


### PR DESCRIPTION
fixes #31 
Turns out it wasn't a simple bug. The issue was in the `Plug.Debugger` being rendered after toolbar plug, because it was defined in `@before_compile` hook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/38)
<!-- Reviewable:end -->
