### PR TITLE
nilify ExDebugToolbar.pry/0 macro when disabled instead of returning error tuple

### DIFF
--- a/lib/ex_debug_toolbar.ex
+++ b/lib/ex_debug_toolbar.ex
@@ -142,7 +142,7 @@ defmodule ExDebugToolbar do
   Adds a breakpoint that can be interacted with using Breakpoints Panel on toolbar.
   """
   @spec pry() :: nil
-  @decorate noop_when_toolbar_disabled()
+  @decorate noop_when_toolbar_disabled(nil)
   defmacro pry do
     code_snippet = Breakpoint.code_snippet(__CALLER__)
     quote do


### PR DESCRIPTION
Upon adding tests to demo controller, I noticed that `ExDebugToolbar.pry` is not playing along with `Phoenix.HTML.Safe` when toolbar is disabled. Only Tuple like `{:safe, data}` can be rendered, otherwise it raises an error.

 It doesn't look like you can extend existing protocol, which would be ideal. So instead, `pry` returns nil when toolbar is disabled. I think it's the only function that makes sense to use in a template. Even then, highly unlikely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/39)
<!-- Reviewable:end -->
