### PR TITLE
try to cast binary params in ecto logs into Ecto.UUID

### DIFF
--- a/lib/ex_debug_toolbar/collector/ecto_collector.ex
+++ b/lib/ex_debug_toolbar/collector/ecto_collector.ex
@@ -28,19 +28,15 @@ if Code.ensure_compiled?(Ecto) do
     end
     defp remove_result_rows(entry), do: entry
 
-    defp cast_params(entry, processed \\ [])
-    defp cast_params(%{params: params} = entry, _) do
-      %{entry | params: cast_params(params)}
+    defp cast_params(%{params: params} = entry) do
+      %{entry | params: Enum.map(params, &cast_param/1)}
     end
-    defp cast_params([value | rest], processed) when is_bitstring(value) do
-      value = case Ecto.UUID.cast(value) do
+    defp cast_param(value) when is_bitstring(value) do
+      case Ecto.UUID.cast(value) do
         {:ok, uuid} -> uuid
         :error -> "__BINARY__"
       end
-      cast_params(rest, [value | processed])
     end
-    defp cast_params([value | rest], processed), do: cast_params(rest, [value | processed])
-    defp cast_params([], processed), do: Enum.reverse(processed)
-    defp cast_params(entry, _), do: entry
+    defp cast_param(value), do: value
   end
 end

--- a/lib/ex_debug_toolbar/collector/ecto_collector.ex
+++ b/lib/ex_debug_toolbar/collector/ecto_collector.ex
@@ -4,12 +4,12 @@ if Code.ensure_compiled?(Ecto) do
 
     alias Ecto.LogEntry
 
-    def log(%LogEntry{} = entry) do
+    def log(%LogEntry{} = original_entry) do
+      entry = original_entry |> remove_result_rows |> cast_params
       {id, duration, type} = parse_entry(entry)
-      entry = remove_result_rows(entry)
       ExDebugToolbar.add_finished_event(id, "ecto.query", duration)
       ExDebugToolbar.add_data(id, :ecto, {entry, duration, type})
-      entry
+      original_entry
     end
 
     defp parse_entry(entry) do
@@ -27,5 +27,20 @@ if Code.ensure_compiled?(Ecto) do
       %{entry | result: {:ok, %{result | rows: []}}}
     end
     defp remove_result_rows(entry), do: entry
+
+    defp cast_params(entry, processed \\ [])
+    defp cast_params(%{params: params} = entry, _) do
+      %{entry | params: cast_params(params)}
+    end
+    defp cast_params([value | rest], processed) when is_bitstring(value) do
+      value = case Ecto.UUID.cast(value) do
+        {:ok, uuid} -> uuid
+        :error -> "__BINARY__"
+      end
+      cast_params(rest, [value | processed])
+    end
+    defp cast_params([value | rest], processed), do: cast_params(rest, [value | processed])
+    defp cast_params([], processed), do: Enum.reverse(processed)
+    defp cast_params(entry, _), do: entry
   end
 end

--- a/test/lib/ex_debug_toolbar/collector/ecto_collector_test.exs
+++ b/test/lib/ex_debug_toolbar/collector/ecto_collector_test.exs
@@ -74,6 +74,12 @@ defmodule ExDebugToolbar.Collector.EctoCollectorTest do
     assert {%{params: ["__BINARY__"]}, _, _} = request.ecto |> hd
   end
 
+  test "the order of params in a query is preserved" do
+    %Ecto.LogEntry{query: "query", params: [1, 2, 3]} |> Collector.log
+    assert {:ok, request} = get_request()
+    assert {%{params: [1, 2, 3]}, _, _} = request.ecto |> hd
+  end
+
   test "it returns unmodified entry" do
     entry = %Ecto.LogEntry{
       query: "query",


### PR DESCRIPTION
addresses #49 
We try to replace binary params with uuid string for `Ecto.UUID` values or with a placeholder otherwise to avoid encoding issue later on in the channel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/50)
<!-- Reviewable:end -->
