### PR TITLE
Fix/integer keys in breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ To change configuration, update `:ex_debug_toolbar` config key in your `config/d
 
 # Troubleshooting
 
+### Poison encode issues
+
+If you see `poison` encode related errors in your logs:
+* update to latest `poison` package version
+* enable debug mode and open an issue with detailed logs
+
 ### Debug mode
 
 When enabled, toolbar prints debug logs.

--- a/lib/ex_debug_toolbar/breakpoint/uuid.ex
+++ b/lib/ex_debug_toolbar/breakpoint/uuid.ex
@@ -4,7 +4,7 @@ defmodule ExDebugToolbar.Breakpoint.UUID do
   def from_string(uuid) do
     case String.split(uuid, "-") do
       [request_id, breakpoint_id] ->
-        {:ok, %__MODULE__{request_id: request_id, breakpoint_id: String.to_integer(breakpoint_id)}}
+        {:ok, %__MODULE__{request_id: request_id, breakpoint_id: breakpoint_id}}
       _ -> {:error, "cannot parse uuid #{uuid}"}
     end
   end

--- a/lib/ex_debug_toolbar/data/breakpoint_collection.ex
+++ b/lib/ex_debug_toolbar/data/breakpoint_collection.ex
@@ -21,7 +21,7 @@ defimpl Collection, for: BreakpointCollection do
 
   def add(%{count: @breakpoints_limit} = breakpoints, %Breakpoint{}), do: breakpoints
   def add(%{count: count} = breakpoints, %Breakpoint{id: nil} = breakpoint) do
-    add(breakpoints, %{breakpoint | id: count})
+    add(breakpoints, %{breakpoint | id: to_string(count)})
   end
   def add(breakpoints, %Breakpoint{} = breakpoint) do
     %{

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule ExDebugToolbar.Mixfile do
       {:phoenix_pubsub, "~> 1.0"},
       {:phoenix_html, "~> 2.6"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
-      {:phoenix_slime, "~> 0.8.0", optional: true},
+      {:phoenix_slime, "~> 0.8", optional: true},
       {:ecto, "~> 2.1", optional: true},
       {:postgrex, "~> 0.13", optional: true},
       {:gettext, "~> 0.11"},

--- a/test/lib/ex_debug_toolbar/breakpoint/uuid_test.exs
+++ b/test/lib/ex_debug_toolbar/breakpoint/uuid_test.exs
@@ -3,7 +3,7 @@ defmodule ExDebugToolbar.Breakpoints.UUIDTest do
   alias ExDebugToolbar.Breakpoint.UUID
 
   test "serializing and unserializing uuid returns the same value" do
-    uuid = %UUID{request_id: "asdaf", breakpoint_id: 5}
+    uuid = %UUID{request_id: "asdaf", breakpoint_id: "5"}
     {:ok, unserialized} = UUID.from_string(to_string(uuid))
     assert uuid == unserialized
   end


### PR DESCRIPTION
integer keys don't play well with older `poison` package version, and phoenix 1.2 depends on it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kagux/ex_debug_toolbar/61)
<!-- Reviewable:end -->
